### PR TITLE
Update to use Macchina-provided single-wire CAN library

### DIFF
--- a/M2RET.ino
+++ b/M2RET.ino
@@ -34,7 +34,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <due_wire.h>
 #include <SPI.h>
 #include <lin_stack.h>
-#include <sw_can.h>
+#include <MCP2515_sw_can.h>
 #include "ELM327_Emulator.h"
 
 #include "EEPROM.h"
@@ -405,7 +405,7 @@ void sendFrame(CANRaw &bus, CAN_FRAME &frame)
 
 void sendFrameSW(CAN_FRAME &frame)
 {
-    SWFRAME swFrame;
+    Frame swFrame;
     swFrame.id = frame.id;
     swFrame.extended = frame.extended;
     swFrame.length = frame.length;
@@ -654,7 +654,7 @@ void loop()
 {
     static int loops = 0;
     CAN_FRAME incoming;
-    SWFRAME swIncoming;
+    Frame swIncoming;
     static CAN_FRAME build_out_frame;
     static int out_bus;
     int in_byte;

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ A fork of the GVRET project.
 You will need the following to be able to compile the run this project:
 
 - [Arduino IDE](https://www.arduino.cc/en/Main/Software) 1.5.4 or higher (tested all of the way up to 1.6.12)
-- [M2 Board Files] (https://github.com/macchina/arduino-boards-sam) - Needed to define the pins for various hardware
+- [M2 Board Configuration](https://github.com/macchina/arduino-boards-sam) - Needed to define the pins for various hardware
 - [due_can](https://github.com/collin80/due_can) - Object oriented canbus library for Arduino Due compatible boards.
 - [due_wire](https://github.com/collin80/due_wire) - An alternative I2C library for Due with DMA support.
-- [Arduino_Due_SD_HSCMI](https://github.com/macchina/Arduino_Due_SD_HSMCI) - SD card support library
-- [SD_HSCMI](https://github.com/collin80/SD_HSCMI) - Another SD support library
+- [M2_SD_HSMCI](https://github.com/macchina/M2_SD_HSMCI) - SD card support library
 - [LIN](https://github.com/macchina/LIN) - Support for the dual LIN ports on the M2
-- [SW_CAN](https://github.com/collin80/SW_CAN) - Single wire CAN support for M2 board
+- [Single-Wire CAN (MCP2515)](https://github.com/macchina/Single-Wire-CAN-mcp2515) - Single wire CAN support for M2 board
+- [MCP2515](https://github.com/macchina/mcp2515) - CAN library that powers the Single-Wire CAN library
 
 All libraries belong in %USERPROFILE%\Documents\Arduino\libraries (Windows) or ~/Arduino/libraries (Linux/Mac).
 You will need to remove -master or any other postfixes. Your library folders should be named as above.

--- a/SerialConsole.cpp
+++ b/SerialConsole.cpp
@@ -29,7 +29,7 @@
 #include "SerialConsole.h"
 #include <due_wire.h>
 #include <due_can.h>
-#include <sw_can.h>
+#include <MCP2515_sw_can.h>
 #include <lin_stack.h>
 #include "EEPROM.h"
 #include "config.h"
@@ -359,7 +359,7 @@ void SerialConsole::handleLawicelCmd()
                 Can1.sendFrame(outFrame);                
             }
             if (!stricmp(tokens[1], "SWCAN")) {
-                SWFRAME swFrame;
+                Frame swFrame;
                 swFrame.id = id;
                 swFrame.length = numBytes;
                 swFrame.extended = false;
@@ -878,7 +878,7 @@ bool SerialConsole::handleSWCANSend(char *inputString)
     char *idTok = strtok(inputString, ",");
     char *lenTok = strtok(NULL, ",");
     char *dataTok;
-    SWFRAME frame;
+    Frame frame;
 
     if (!idTok) return false;
     if (!lenTok) return false;


### PR DESCRIPTION
Modifications needed to use the Macchina-provided single-wire CAN library.  I verified that it compiles/verifies after the changes.